### PR TITLE
[FLINK-19107] Add checkpointing and recovery options to template flink-conf.yaml

### DIFF
--- a/template/flink-distribution/conf/flink-conf.yaml
+++ b/template/flink-distribution/conf/flink-conf.yaml
@@ -14,20 +14,35 @@
 # limitations under the License.
 # This file is the base for the Apache Flink configuration
 
+statefun.flink-job-name: Statefun Application
+
 #==============================================================================
 # Configurations strictly required by Stateful Functions. Do not change.
 #==============================================================================
 
 classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
-execution.checkpointing.max-concurrent-checkpoints: 1
-jobmanager.scheduler: legacy
 
 #==============================================================================
-# Recommended configurations. Users may change according to their needs.
+# Fault tolerance, checkpointing and recovery.
+# For more related configuration options, please see: https://ci.apache.org/projects/flink/flink-docs-master/ops/config.html#fault-tolerance
 #==============================================================================
+
+# Uncomment the below to enable checkpointing for your application
+#execution.checkpointing.mode: EXACTLY_ONCE
+#execution.checkpointing.interval: 5sec
+
+restart-strategy: fixed-delay
+restart-strategy.fixed-delay.attempts: 2147483647
+restart-strategy.fixed-delay.delay: 1sec
 
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+#==============================================================================
+# Recommended memory configurations. Users may change according to their needs.
+#==============================================================================
+
+jobmanager.memory.process.size: 1g
 taskmanager.memory.process.size: 4g


### PR DESCRIPTION
This also removes some no longer required configuration, like max concurrent checkpoints = 1 and legacy scheduler.