### PR TITLE
[FLINK-19408] Update add-version.sh for cross-releasing Java 8 and 11

### DIFF
--- a/add-version.sh
+++ b/add-version.sh
@@ -58,20 +58,25 @@ if [ -z "$gpg_key" ]; then
     error "Missing GPG key ID in gpg_keys.txt file for release $statefun_version"
 fi
 
-if [ -d "$statefun_version" ]; then
-    error "Directory $statefun_version already exists; delete before continuing"
-fi
+function generate_dockerfile() {
+    local java_version="$1"
+    local dir="$statefun_version-java$java_version"
 
-echo -n >&2 "Generating Dockerfiles..."
-dir="$statefun_version"
-mkdir "$dir"
+    echo -n >&2 "Generating Dockerfiles for StateFun version=$statefun_version, Flink version=$flink_version, Java version=$java_version ..."
+    rm -rf $dir
+    mkdir "$dir"
 
-cp -r template/* "$dir"
+    cp -r template/* "$dir"
 
-sed \
-    -e "s/%%STATEFUN_VERSION%%/$statefun_version/" \
-    -e "s/%%FLINK_VERSION%%/$flink_version/" \
-    -e "s/%%GPG_KEY%%/$gpg_key/" \
-    "template/Dockerfile" > "$dir/Dockerfile"
+    sed \
+        -e "s/%%STATEFUN_VERSION%%/$statefun_version/" \
+        -e "s/%%FLINK_VERSION%%/$flink_version/" \
+        -e "s/%%JAVA_VERSION%%/$java_version/" \
+        -e "s/%%GPG_KEY%%/$gpg_key/" \
+        "template/Dockerfile" > "$dir/Dockerfile"
 
-echo >&2 " done."
+    echo >&2 " done."
+}
+
+generate_dockerfile 8
+generate_dockerfile 11

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM flink:%%FLINK_VERSION%%
+FROM flink:%%FLINK_VERSION%%-scala_2.12-java%%JAVA_VERSION%%
 
 ENV STATEFUN_VERSION=%%STATEFUN_VERSION%% \
     GPG_KEY=%%GPG_KEY%%


### PR DESCRIPTION
Now when you execute `./add-version.sh -s <statefun_version> -f <flink_version>`, two directories will be created:
* `<statefun_version>-java8`
* `<statefun_version>-java11`
with each containing the Dockerfiles for the corresponding Java version.

Console output:
![image](https://user-images.githubusercontent.com/5284370/94235838-c5371c80-ff3e-11ea-86ff-44d31dc3572e.png)
