### PR TITLE
[FLINK-22752] More robust state configurations in base flink-conf.yaml

### DIFF
--- a/template/flink-distribution/conf/flink-conf.yaml
+++ b/template/flink-distribution/conf/flink-conf.yaml
@@ -35,10 +35,17 @@ restart-strategy: fixed-delay
 restart-strategy.fixed-delay.attempts: 2147483647
 restart-strategy.fixed-delay.delay: 1sec
 
+state.backend.local-recovery: true
 state.backend: rocksdb
 state.backend.rocksdb.timer-service.factory: ROCKSDB
+state.backend.rocksdb.localdir: /local/state/rocksdb
+state.backend.rocksdb.memory.partitioned-index-filters: true
+state.backend.rocksdb.checkpoint.transfer.thread.num: 8
+state.backend.rocksdb.thread.num: 4
 state.checkpoints.dir: file:///checkpoint-dir
 state.backend.incremental: true
+
+taskmanager.state.local.root-dirs: file:///local/state/recovery
 
 #==============================================================================
 # Recommended memory configurations. Users may change according to their needs.


### PR DESCRIPTION
This PR complements https://github.com/apache/flink-statefun/pull/257 by adapting the changes to our official released Docker images.