### PR TITLE
[FLINK-23964] Move netty*tcnative*jar to lib/

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -79,4 +79,7 @@ RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \
 # entry point 
 ADD docker-entry-point.sh /docker-entry-point.sh
 
+# add tcnative
+RUN mv $FLINK_HOME/opt/flink-shaded-netty-tcnative-dynamic-*.jar  $FLINK_HOME/lib/
+
 ENTRYPOINT ["/docker-entry-point.sh"]


### PR DESCRIPTION
This PR adds Netty's shaded tcnative artifact to lib/, and thus makes `openssl` available to netty.